### PR TITLE
Added get services output for each port from -sV param

### DIFF
--- a/process/host/ports/index.js
+++ b/process/host/ports/index.js
@@ -1,23 +1,25 @@
 const inspect = require('util').inspect,
-  processScript = require('./script')
+    processScript = require('./script')
 
-const processPorts = (ports)=>{
-  var newports = {ports: []}, length = ports[0]
-  if(ports[0].extraports){
-    newports.extraports = ports[0].extraports[0].$
-    if(ports[0].extraports[0].extrareasons) newports.extrareasons = ports[0].extraports[0].extrareasons[0].$
-  }
-  if(ports[0].port){
-    for(var i = 0; i < ports[0].port.length; i++){
-      newports.ports[i] = {}
-      if(ports[0].port[i].$) newports.ports[i].port = ports[0].port[i].$
-      if(ports[0].port[i].state) newports.ports[i].state = ports[0].port[i].state[0].$
-      if(ports[0].port[i].cpe) newports.ports[i].cpe = ports[0].port[i].state[0].cpe[0]
-      if(ports[0].port[i].script) newports.ports[i].script = processScript(ports[0].port[i].script)
+const processPorts = (ports) => {
+    var newports = { ports: [] },
+        length = ports[0]
+    if (ports[0].extraports) {
+        newports.extraports = ports[0].extraports[0].$
+        if (ports[0].extraports[0].extrareasons) newports.extrareasons = ports[0].extraports[0].extrareasons[0].$
     }
-  }
-  
-  return newports
+    if (ports[0].port) {
+        for (var i = 0; i < ports[0].port.length; i++) {
+            newports.ports[i] = {}
+            if (ports[0].port[i].$) newports.ports[i].port = ports[0].port[i].$
+            if (ports[0].port[i].state) newports.ports[i].state = ports[0].port[i].state[0].$
+            if (ports[0].port[i].service) newports.ports[i].service = ports[0].port[i].service[0].$
+            if (ports[0].port[i].cpe) newports.ports[i].cpe = ports[0].port[i].state[0].cpe[0]
+            if (ports[0].port[i].script) newports.ports[i].script = processScript(ports[0].port[i].script)
+        }
+    }
+
+    return newports
 }
 
 module.exports = processPorts


### PR DESCRIPTION
Just added a simple line to get also service running output for each port

Json output before change:
```
"ports": [
      {
        "port": {
          "protocol": "tcp",
          "portid": "22"
        },
        "state": {
          "state": "open",
          "reason": "syn-ack",
          "reason_ttl": "0"
        }
      } 
]
```
Json output after change:
```
"ports": [
      {
        "port": {
          "protocol": "tcp",
          "portid": "22"
        },
        "state": {
          "state": "open",
          "reason": "syn-ack",
          "reason_ttl": "0"
        },
        "service": {
          "name": "ssh",
          "product": "OpenSSH",
          "version": "7.4p1 Debian 10+deb9u6",
          "extrainfo": "protocol 2.0",
          "ostype": "Linux",
          "method": "probed",
          "conf": "10"
        }
      }
]
```